### PR TITLE
Add fetch_devedition function to `generate.nu`

### DIFF
--- a/generate.nu
+++ b/generate.nu
@@ -5,8 +5,8 @@ def to_sri (hash: string) {
   return $"sha512-($hash | decode hex | encode base64)"
 }
 
-def fetch_release (version: string, system: string, extension: string) {
-  let base = $"https://download.cdn.mozilla.net/pub/firefox/releases/($version)"
+def fetch (edition: string, version: string, system: string, extension: string) {
+  let base = $"https://download.cdn.mozilla.net/pub/($edition)/releases/($version)"
 
   let filename = $"($system)/en-US/firefox-($version).($extension)"
 
@@ -29,28 +29,12 @@ def fetch_release (version: string, system: string, extension: string) {
   }
 }
 
+def fetch_release (version: string, system: string, extension: string) {
+  return (fetch "firefox" $version $system $extension)
+}
+
 def fetch_devedition (version: string, system: string, extension: string) {
-  let base = $"https://download.cdn.mozilla.net/pub/devedition/releases/($version)"
-
-  let filename = $"($system)/en-US/firefox-($version).($extension)"
-
-  let row = (
-    http get $"($base)/SHA512SUMS"
-    | from ssv -m 1 --noheaders
-    | where column1 == $filename
-  )
-
-  if ($row | is-not-empty) {
-    let hash = $row.column0.0
-
-    return {
-      version: $version,
-      url: $"($base)/($filename)",
-      hash: (to_sri $hash)
-    }
-  } else {
-    return null
-  }
+  return (fetch "devedition" $version $system $extension)
 }
 
 def fetch_nightly (version: string, system: string) {

--- a/latest.json
+++ b/latest.json
@@ -17,8 +17,8 @@
     },
     "devedition": {
       "version": "148.0b8",
-      "url": "https://download.cdn.mozilla.net/pub/devedition/releases/148.0b8/linux-x86_64/en-US/firefox-148.0b8.tar.xz",
-      "hash": "sha512-Y87vBRAfsySpBRvTaBt/XvJv2uol0TyEiGkx9ZGm7PVM7fNVaJif3BRQfjWaESfO16tluGvvfX3PZxInIP/U6w=="
+      "url": "https://download.cdn.mozilla.net/pub/firefox/releases/148.0b8/linux-x86_64/en-US/firefox-148.0b8.tar.xz",
+      "hash": "sha512-6cVp7S61mv+N6YE71iRU7/yp+PvlBTsrZqFvAsby9MHtcciVNRttO0qqBD6nP0OMCGucKTMHkQG8hR65dCHgpw=="
     },
     "nightly": {
       "version": "149.0a1",
@@ -45,8 +45,8 @@
     },
     "devedition": {
       "version": "148.0b8",
-      "url": "https://download.cdn.mozilla.net/pub/devedition/releases/148.0b8/linux-aarch64/en-US/firefox-148.0b8.tar.xz",
-      "hash": "sha512-7VttMkoaY85ftciiJejch6c6LAtCLWPzFvZEsXHgNqzBYmwg1YKQQKZl5XKU9oylY8XhL0L60RYiDNro/RXDmw=="
+      "url": "https://download.cdn.mozilla.net/pub/firefox/releases/148.0b8/linux-aarch64/en-US/firefox-148.0b8.tar.xz",
+      "hash": "sha512-9KTN4Gd6qptlqImEXUKAg6AAQoGVxXDnQZyjyO0b2SmBSuSUhpFZbWYZlL+hXJw42cngZdefPPqqWwhu0ZZpig=="
     },
     "nightly": {
       "version": "149.0a1",

--- a/latest.json
+++ b/latest.json
@@ -17,8 +17,8 @@
     },
     "devedition": {
       "version": "148.0b8",
-      "url": "https://download.cdn.mozilla.net/pub/firefox/releases/148.0b8/linux-x86_64/en-US/firefox-148.0b8.tar.xz",
-      "hash": "sha512-6cVp7S61mv+N6YE71iRU7/yp+PvlBTsrZqFvAsby9MHtcciVNRttO0qqBD6nP0OMCGucKTMHkQG8hR65dCHgpw=="
+      "url": "https://download.cdn.mozilla.net/pub/devedition/releases/148.0b8/linux-x86_64/en-US/firefox-148.0b8.tar.xz",
+      "hash": "sha512-Y87vBRAfsySpBRvTaBt/XvJv2uol0TyEiGkx9ZGm7PVM7fNVaJif3BRQfjWaESfO16tluGvvfX3PZxInIP/U6w=="
     },
     "nightly": {
       "version": "149.0a1",
@@ -45,8 +45,8 @@
     },
     "devedition": {
       "version": "148.0b8",
-      "url": "https://download.cdn.mozilla.net/pub/firefox/releases/148.0b8/linux-aarch64/en-US/firefox-148.0b8.tar.xz",
-      "hash": "sha512-9KTN4Gd6qptlqImEXUKAg6AAQoGVxXDnQZyjyO0b2SmBSuSUhpFZbWYZlL+hXJw42cngZdefPPqqWwhu0ZZpig=="
+      "url": "https://download.cdn.mozilla.net/pub/devedition/releases/148.0b8/linux-aarch64/en-US/firefox-148.0b8.tar.xz",
+      "hash": "sha512-7VttMkoaY85ftciiJejch6c6LAtCLWPzFvZEsXHgNqzBYmwg1YKQQKZl5XKU9oylY8XhL0L60RYiDNro/RXDmw=="
     },
     "nightly": {
       "version": "149.0a1",


### PR DESCRIPTION
This pull request updates how the "devedition" (Developer Edition) Firefox builds are fetched and referenced. The main change is that "devedition" is now retrieved from its correct upstream location, which is separate from the standard Firefox releases. This ensures the correct URLs and hashes are used for these builds.

Fixes #61