### PR TITLE
fix: add libva to runtimeDependencies

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -18,6 +18,7 @@
   dbus-glib,
   gtk3,
   libxtst,
+  libva,
   pciutils,
   pipewire,
   adwaita-icon-theme,
@@ -57,6 +58,7 @@ stdenv.mkDerivation {
   runtimeDependencies = [
     curl
     pciutils
+    libva.out
   ];
 
   appendRunpaths = [


### PR DESCRIPTION
This matches upstream, which has it here:
https://github.com/NixOS/nixpkgs/blob/ad88f12aa9d8aad03df3dd85fcbf914c7355dce7/pkgs/applications/networking/browsers/firefox-bin/default.nix#L102